### PR TITLE
Fix toStep for speed fan

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -157,7 +157,7 @@ export class CeilingFanAccessory {
 
   toStep(percent: number) {
     const etapes = [1, 2, 3, 4, 5, 6];
-    const etapeIndex = Math.floor(percent / 16.67); // 100 / 6 = 16.67
+    const etapeIndex = Math.floor(percent / 16.66); // 100 / 6 = 16.66
     return etapes[etapeIndex];
   }
 


### PR DESCRIPTION
If we leave 16.67 with 100, it returns to 5 so it never reaches speed 6

```javascript
-> Math.floor(100/16.67)
<- 5
-> Math.floor(100/16.66)
<- 6
``` 